### PR TITLE
module and oval fixes

### DIFF
--- a/vmaas/common_test.go
+++ b/vmaas/common_test.go
@@ -295,7 +295,7 @@ func TestNevraPkgID(t *testing.T) {
 }
 
 func TestNevraUpdates(t *testing.T) {
-	updates := nevraUpdates(nil, nil)
+	updates, _ := nevraUpdates(nil, nil, nil)
 	assert.Nil(t, updates)
 
 	// cache init
@@ -330,7 +330,7 @@ func TestNevraUpdates(t *testing.T) {
 	}
 
 	ids := extractNevraIDs(&c, &nevra) // ids.NameID=1, EvrIDs=[2, 3, 4], ArchID=3
-	updates = nevraUpdates(&c, &ids)
+	updates, _ = nevraUpdates(&c, &ids, nil)
 	// update for PkgID=3
 	assert.Equal(t, []PkgID{6, 7}, updates)
 }

--- a/vmaas/vulnerabilities.go
+++ b/vmaas/vulnerabilities.go
@@ -334,8 +334,7 @@ func evaluateState(c *Cache, state OvalState, nevra utils.Nevra) (matched bool) 
 
 func evaluateModuleTest(c *Cache, moduleTestID ModuleTestID, modules map[string]string) bool {
 	testDetail := c.OvalModuleTestDetail[moduleTestID]
-	_, ok := modules[testDetail.ModuleStream.Module]
-	return ok
+	return modules[testDetail.ModuleStream.Module] == testDetail.ModuleStream.Stream
 }
 
 func evaluateTest(c *Cache, testID TestID, pkgNameID NameID, nevra utils.Nevra) (matched bool) {


### PR DESCRIPTION
- fix VMAAS-1452, update from EPEL when module is enabled

tested with:
pkg: `"softhsm-2.6.0-3.module+el8.3.0+6909+fb33717d.x86_64"`
modules: `389-ds:1.4`, `httpd:2.4`, `pki-core:10.6`, `pki-deps:10.6` (requires) `idm:DL1` (provides softhsm pkg)
repos: `"epel-8", "rhel-8-for-x86_64-baseos-rpms", "rhel-8-for-x86_64-appstream-rpms"`

when all modules are provided and pkg is associated with an erratum, we can find that the packages is from the module and then we show only errata from modules in response. If at least 1 of required modules is not enabled, we show update from epel.

it won't work when pkg has no associated errata, we won't be able to map pkg to module

- fix duplicates in UnpatchedCVEs list
- fix OVAL with modules - check module stream

