### PR TITLE
fix(oval): unpatched cves take precedence over fixable and manually f…

### DIFF
--- a/vmaas/load.go
+++ b/vmaas/load.go
@@ -756,13 +756,7 @@ func loadErrataModules() map[int][]Module {
 func loadOvalDefinitionDetail(c *Cache) {
 	defer utils.TimeTrack(time.Now(), "oval_definition_detail")
 
-	type OvalDefinitionDetail struct {
-		ID               DefinitionID
-		DefinitionTypeID int
-		CriteriaID       CriteriaID
-	}
-
-	row := OvalDefinitionDetail{}
+	row := DefinitionDetail{}
 	defDetail := make(map[DefinitionID]DefinitionDetail)
 	rows := getAllRows("oval_definition_detail", "id,definition_type_id,criteria_id", "id")
 
@@ -770,10 +764,7 @@ func loadOvalDefinitionDetail(c *Cache) {
 		if err := rows.Scan(&row.ID, &row.DefinitionTypeID, &row.CriteriaID); err != nil {
 			panic(err)
 		}
-		defDetail[row.ID] = DefinitionDetail{
-			DefinitionTypeID: row.DefinitionTypeID,
-			CriteriaID:       row.CriteriaID,
-		}
+		defDetail[row.ID] = row
 	}
 	c.OvaldefinitionDetail = defDetail
 }


### PR DESCRIPTION
…ixable

Benchmark of `evaluate` function with 2 vmaas jsons (1 rhel7, 1 rhel8) ran 10x (so it actually ran 20x 😄 )
```
BenchmarkEvaluate/evaluate-8         	      10	 365585917 ns/op
BenchmarkNewEvaluate/newEvaluate-8   	      10	 237108050 ns/op
```

evaluation of RHEL 8 with 538 packages took ~77ms
evaluation of RHEL 7 with 1550 packages took ~156ms