### PR TITLE
fix(modules): package from module with disabled repo

### DIFF
--- a/vmaas/common_test.go
+++ b/vmaas/common_test.go
@@ -295,7 +295,7 @@ func TestNevraPkgID(t *testing.T) {
 }
 
 func TestNevraUpdates(t *testing.T) {
-	updates, _ := nevraUpdates(nil, nil, nil)
+	updates, _ := nevraUpdates(nil, nil, nil, nil)
 	assert.Nil(t, updates)
 
 	// cache init
@@ -330,7 +330,7 @@ func TestNevraUpdates(t *testing.T) {
 	}
 
 	ids := extractNevraIDs(&c, &nevra) // ids.NameID=1, EvrIDs=[2, 3, 4], ArchID=3
-	updates, _ = nevraUpdates(&c, &ids, nil)
+	updates, _ = nevraUpdates(&c, &ids, nil, nil)
 	// update for PkgID=3
 	assert.Equal(t, []PkgID{6, 7}, updates)
 }


### PR DESCRIPTION
show non-modular update with enabled module but not enabled repo for that module e.g.

```
{
  "package_list": ["libssh2-0:1.8.0-8.module+el8.0.0+4084+cceb9f44.1.x86_64"],
  "repository_list": ["cfme-5.11-for-rhel-8-x86_64-rpms"],
  "modules_list": [{"module_name": "virt", "module_stream": "rhel"}]
}
```
should show non-modular update from `cfme` repo because `virt:rhel` is a module from `rhel-8-for-x86_64-appstream-rpms` which is not enabled

VMAAS-1452