### PR TITLE
fix: nil pointer dereference

### DIFF
--- a/vmaas/cache.go
+++ b/vmaas/cache.go
@@ -72,7 +72,7 @@ type Cache struct {
 	CpeID2Label                     map[CpeID]string
 }
 
-func (c *Cache) ShouldReload(latestDumpEndpoint string) bool {
+func ShouldReload(c *Cache, latestDumpEndpoint string) bool {
 	if c == nil {
 		return true
 	}

--- a/vmaas/vmaas.go
+++ b/vmaas/vmaas.go
@@ -81,7 +81,7 @@ func (api *API) PeriodicCacheReload(interval time.Duration, latestDumpEndpoint s
 
 	go func() {
 		for range ticker.C {
-			reloadNeeded := api.Cache.ShouldReload(latestDumpEndpoint)
+			reloadNeeded := ShouldReload(api.Cache, latestDumpEndpoint)
 			if !reloadNeeded {
 				continue
 			}


### PR DESCRIPTION
happens when you create `new(API)`, `Cache` is then `nil` and `nil` can't be used as a receiver