### PR TITLE
fix: check whether pkg update exists in enabled repo

### DIFF
--- a/vmaas/common.go
+++ b/vmaas/common.go
@@ -224,6 +224,19 @@ func pkgErrataUpdates(c *Cache, pkgID PkgID, erratumID ErratumID, modules map[in
 
 	repos := filterErrataRepos(c, erratumID, repoIDs)
 	for _, r := range repos {
+		// filter out update package if it does not exist in the enabled repo
+		pkgInRepo := false
+		pkgRepos := c.PkgID2RepoIDs[pkgID]
+		for _, pkgRepo := range pkgRepos {
+			if r == pkgRepo {
+				pkgInRepo = true
+				break
+			}
+		}
+		if !pkgInRepo {
+			return
+		}
+
 		details := c.RepoDetails[r]
 		updates <- Update{
 			Package:     nevra.String(),


### PR DESCRIPTION
problem arises when same errata exists in multiple repos, then we can show package update which does not exist in enabled repos

currently it shows wrong updates for `satellite-clone-0:3.1.1-2.el7sat.noarch` in `rhel-7-server-satellite-maintenance-6.11-rpms` - e.g. `satellite-clone-3.1.1-2.el8sat.noarch` which has the same erratum as package in rhel-7 repo

before:
```
satellite-clone-3.1.1-3.el8sat.noarch, RHBA-2023:3631
satellite-clone-3.1.1-3.el7sat.noarch, RHBA-2023:3631
satellite-clone-3.1.1-2.el8sat.noarch, RHSA-2023:1151
```

after
```
satellite-clone-3.1.1-3.el7sat.noarch, RHBA-2023:3631
```

the fix should not affect any previous functionality with epel or optimistic updates