### PR TITLE
Improve speed and consistency of updates response

### DIFF
--- a/vmaas/common.go
+++ b/vmaas/common.go
@@ -258,7 +258,7 @@ func pkgErrataUpdates(c *Cache, pkgID PkgID, erratumID ErratumID, modules map[in
 			}
 		}
 		if !pkgInRepo {
-			return
+			continue
 		}
 
 		details := c.RepoDetails[r]


### PR DESCRIPTION
I tried that with a rpm list from some old rhel8, performance improvement seems significant on my laptop but let's see how it goes in openshift
before: 80-110ms to get 10916 updates
now: 20-30ms