### PR TITLE
fix: skip processing of duplicate products

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/ezamriy/gorpm v0.0.0-20160905202458-25f7273cbf51
+	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=


### PR DESCRIPTION
don't add duplicate affected packages to extended response
before
```
INFO[0013] Vulnerabilities                               unpatched cves="[{CVE-2022-40897 map[python3-setuptools-0:39.2.0-10.el7.noarch:true] map[] [{python3-setuptools 0:39.2.0-10.el7.noarch cpe:/o:redhat:enterprise_linux:7 {<nil> <nil>}} {python3-setuptools 0:39.2.0-10.el7.noarch cpe:/o:redhat:enterprise_linux:7 {<nil> <nil>}}]}]"
```
after
```
INFO[0013] Vulnerabilities                               unpatched cves="[{CVE-2022-40897 map[python3-setuptools-0:39.2.0-10.el7.noarch:true] map[] [{python3-setuptools 0:39.2.0-10.el7.noarch cpe:/o:redhat:enterprise_linux:7 {<nil> <nil>}}]}]"
```