### PR TITLE
fix: reuse product struct for products with unfixed cves

### DIFF
--- a/vmaas/vulnerabilities.go
+++ b/vmaas/vulnerabilities.go
@@ -337,10 +337,11 @@ func contentSets2cpes(c *Cache, csIDs []ContentSetID) []CpeID {
 }
 
 func productsWithUnfixedCVEs(c *Cache, cpe CpeID, nameID NameID, modules []ModuleStream) []CSAFProduct {
-	products := make([]CSAFProduct, 0, len(modules)+1)
+	products := make([]CSAFProduct, 0, len(modules))
 	cn := CpeIDNameID{CpeID: cpe, NameID: nameID}
+	product := CSAFProduct{CpeID: cpe, PackageNameID: nameID}
 	for _, ms := range modules {
-		product := CSAFProduct{CpeID: cpe, PackageNameID: nameID, ModuleStream: ms}
+		product.ModuleStream = ms
 		if _, ok := c.CSAFCVEs[cn][product]; ok {
 			products = append(products, product)
 		}


### PR DESCRIPTION
vmaas.productsWithUnfixedCVEs is a function with the most mem allocations
```
25.50GB 22.85% 22.85%    25.50GB 22.85%  github.com/redhatinsights/vmaas-lib/vmaas.productsWithUnfixedCVEs /vmaas/go/pkg/mod/github.com/redhatinsights/vmaas-lib@v1.11.1/vmaas/vulnerabilities.go:340
```

that particular line is in top 5 lines from our code using CPU (with this exclude list `hide=runtime|encoding|compress|gin-gonic|gin-contrib|ezamriy`)
```
170ms  1.83% 22.65%      210ms  2.27%  github.com/redhatinsights/vmaas-lib/vmaas.productsWithUnfixedCVEs /vmaas/go/pkg/mod/github.com/redhatinsights/vmaas-lib@v1.11.1/vmaas/vulnerabilities.go:344
```
we could also experiment with memory allocations in `cpes2products` which is close second in terms of space allocation
```
      flat  flat%   sum%        cum   cum%
   25.50GB 22.85% 22.85%    25.50GB 22.85%  github.com/redhatinsights/vmaas-lib/vmaas.productsWithUnfixedCVEs /vmaas/go/pkg/mod/github.com/redhatinsights/vmaas-lib@v1.11.1/vmaas/vulnerabilities.go:340
   23.19GB 20.78% 43.63%    23.19GB 20.78%  github.com/redhatinsights/vmaas-lib/vmaas.cpes2products /vmaas/go/pkg/mod/github.com/redhatinsights/vmaas-lib@v1.11.1/vmaas/vulnerabilities.go:372
``` 

it is properly cleaned as there is not any excesive memory usage but lowering number of allocations should help us with running garbage collector less often