### PR TITLE
rewrite vmaas errata endpoint in go

### DIFF
--- a/vmaas/cache_test.go
+++ b/vmaas/cache_test.go
@@ -30,6 +30,7 @@ func TestPackageIDs2Nevras(t *testing.T) {
 	assert.Equal(t, "kernel-devel-1:1-1.src", sourcePackages[0])
 }
 
+//nolint:funlen
 func mockCache() *Cache {
 	modifiedDate, _ := time.Parse(time.RFC3339, "2024-10-03T11:44:00+02:00")
 	publishedDate, _ := time.Parse(time.RFC3339, "2024-10-03T11:44:00+02:00")
@@ -56,9 +57,42 @@ func mockCache() *Cache {
 			3: {NameID: 2, EvrID: 1, ArchID: 2}, // kernel-devel-1:1-1
 		},
 
+		ErratumDetails: map[string]ErratumDetail{
+			"RHSA-2024:0042": {
+				ThirdParty: false,
+				Type:       "security",
+				Severity:   "Important",
+				PkgIDs:     []int{2, 3},
+			},
+			"RHSA-2024:1111": {
+				ThirdParty: true,
+				Type:       "bugfix",
+				Severity:   "Low",
+			},
+		},
+
 		ErratumID2Name: map[ErratumID]string{
 			1: "RHSA-2024:0042",
 			2: "RHSA-2024:1111",
+		},
+
+		ErratumID2RepoIDs: map[ErratumID]map[RepoID]bool{
+			1: {
+				41: true,
+				42: true,
+			},
+			2: {
+				42: true,
+				43: true,
+				44: true,
+			},
+		},
+
+		RepoDetails: map[RepoID]RepoDetail{
+			41: {},
+			42: {Releasever: "8.2"},
+			43: {Releasever: "8.3"},
+			44: {Releasever: "8.4"},
 		},
 
 		CveDetail: map[string]CveDetail{

--- a/vmaas/errata.go
+++ b/vmaas/errata.go
@@ -1,0 +1,112 @@
+package vmaas
+
+import (
+	"slices"
+
+	"github.com/pkg/errors"
+	"github.com/redhatinsights/vmaas-lib/vmaas/utils"
+)
+
+type ErrataDetails map[string]ErratumDetail
+
+type Errata struct {
+	ErrataList ErrataDetails `json:"errata_list"`
+	Type       []string      `json:"type,omitempty"`
+	Severity   []string      `json:"severity,omitempty"`
+	LastChange string        `json:"last_change"`
+	utils.PaginationDetails
+}
+
+func (req *ErrataRequest) getSortedErrata(c *Cache) ([]string, error) {
+	if len(req.Errata) == 0 {
+		return nil, errors.New("errata_list must contain at least one item")
+	}
+	errata := utils.TryExpandRegexPattern(req.Errata, c.ErratumDetails)
+	slices.Sort(errata)
+	return errata, nil
+}
+
+func filterInputErrata(c *Cache, errata []string, req *ErrataRequest) []string {
+	isDuplicate := make(map[string]bool, len(errata))
+	filteredErrata := make([]string, 0, len(errata))
+	for _, erratum := range errata {
+		if erratum == "" || isDuplicate[erratum] {
+			continue
+		}
+		erratumDetail, found := c.ErratumDetails[erratum]
+		if !found {
+			continue
+		}
+
+		if !req.ThirdParty && erratumDetail.ThirdParty {
+			continue
+		}
+
+		if req.ModifiedSince != nil {
+			if erratumDetail.Issued != nil && erratumDetail.Issued.Before(*req.ModifiedSince) {
+				continue
+			}
+			if erratumDetail.Updated != nil && erratumDetail.Updated.Before(*req.ModifiedSince) {
+				continue
+			}
+		}
+
+		if req.Type != nil && !slices.Contains(req.Type, erratumDetail.Type) {
+			continue
+		}
+		if req.Severity != nil && !slices.Contains(req.Severity, erratumDetail.Severity) {
+			continue
+		}
+
+		filteredErrata = append(filteredErrata, erratum)
+		isDuplicate[erratum] = true
+	}
+	return filteredErrata
+}
+
+func (c *Cache) erratumID2Releasevers(erratumID ErratumID) []string {
+	erratumRepos := c.ErratumID2RepoIDs[erratumID]
+	releaseVers := make([]string, 0, len(erratumRepos))
+	isDuplicate := make(map[string]bool, len(erratumRepos))
+	for repoID := range erratumRepos {
+		repoDetail := c.RepoDetails[repoID]
+		releaseVer := repoDetail.Releasever
+		if releaseVer != "" && !isDuplicate[releaseVer] {
+			releaseVers = append(releaseVers, releaseVer)
+			isDuplicate[releaseVer] = true
+		}
+	}
+	return releaseVers
+}
+
+func (c *Cache) loadErrataDetails(errata []string) ErrataDetails {
+	errataDetails := make(ErrataDetails, len(errata))
+	for _, erratum := range errata {
+		erratumDetail := c.ErratumDetails[erratum]
+		binPackages, sourcePackages := c.packageIDs2Nevras(erratumDetail.PkgIDs)
+		erratumDetail.PackageList = binPackages
+		erratumDetail.SourcePackageList = sourcePackages
+		erratumDetail.ReleaseVersions = c.erratumID2Releasevers(erratumDetail.ID)
+		errataDetails[erratum] = erratumDetail
+	}
+	return errataDetails
+}
+
+func (req *ErrataRequest) errata(c *Cache) (*Errata, error) { // TODO: implement opts
+	errata, err := req.getSortedErrata(c)
+	if err != nil {
+		return nil, err
+	}
+
+	errata = filterInputErrata(c, errata, req)
+	errata, paginationDetails := utils.Paginate(errata, req.PageNumber, req.PageSize)
+
+	res := Errata{
+		ErrataList:        c.loadErrataDetails(errata),
+		Type:              req.Type,
+		Severity:          req.Severity,
+		LastChange:        c.DBChange.LastChange,
+		PaginationDetails: paginationDetails,
+	}
+	return &res, nil
+}

--- a/vmaas/errata_test.go
+++ b/vmaas/errata_test.go
@@ -1,0 +1,66 @@
+package vmaas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrata(t *testing.T) {
+	c := mockCache()
+	req := &ErrataRequest{}
+
+	// empty errata list
+	_, err := req.errata(c)
+	assert.Error(t, err)
+}
+
+func TestGetSortedErrata(t *testing.T) {
+	req := mockErrataRequest()
+	emptyReq := &ErrataRequest{}
+	c := mockCache()
+
+	errata, err := req.getSortedErrata(c)
+	assert.NoError(t, err)
+	assert.Equal(t, "RHSA-2024:0042", errata[0])
+	assert.Equal(t, "RHSA-2024:1111", errata[1])
+	assert.Equal(t, "RHSA-2024:9999", errata[3])
+
+	_, err = emptyReq.getSortedErrata(c)
+	assert.Error(t, err)
+}
+
+func TestFilterInputErrata(t *testing.T) {
+	c := mockCache()
+	req := mockErrataRequest()
+	errata := filterInputErrata(c, req.Errata, req)
+	assert.Equal(t, 2, len(errata))
+}
+
+func TestLoadErrataReleaseVersions(t *testing.T) {
+	c := mockCache()
+	relVers := c.erratumID2Releasevers(1)
+	assert.Equal(t, "8.2", relVers[0])
+
+	relVers = c.erratumID2Releasevers(2)
+	assert.Equal(t, 3, len(relVers))
+}
+
+func TestLoadErrataDetails(t *testing.T) {
+	c := mockCache()
+	errata := []string{"RHSA-2024:0042", "RHSA-2024:1111"}
+	errataDetails := c.loadErrataDetails(errata)
+	assert.Equal(t, 2, len(errataDetails))
+	ed := errataDetails["RHSA-2024:0042"]
+	assert.Equal(t, 1, len(ed.PackageList))
+	assert.Equal(t, 1, len(ed.SourcePackageList))
+}
+
+func mockErrataRequest() *ErrataRequest {
+	return &ErrataRequest{
+		Errata:     []string{"RHSA-2024:0042", "RHSA-2024:1111", "RHSA-2024:1111", "RHSA-2024:9999"},
+		ThirdParty: true,
+		Type:       []string{"security", "bugfix"},
+		Severity:   []string{"Low", "Moderate", "Important", "Critical"},
+	}
+}

--- a/vmaas/types_test.go
+++ b/vmaas/types_test.go
@@ -1,0 +1,28 @@
+package vmaas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalJSON(t *testing.T) {
+	var val StringSlice
+	parseToNilJSONs := [][]byte{[]byte("null"), []byte(""), []byte(`""`)}
+	justStringJSON := []byte(`"foo"`)
+	stringArrayJSON := []byte(`["foo", "bar"]`)
+
+	for _, json := range parseToNilJSONs {
+		err := val.UnmarshalJSON(json)
+		assert.NoError(t, err)
+		assert.Nil(t, val)
+	}
+
+	err := val.UnmarshalJSON(justStringJSON)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(val))
+
+	err = val.UnmarshalJSON(stringArrayJSON)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(val))
+}

--- a/vmaas/vmaas.go
+++ b/vmaas/vmaas.go
@@ -58,6 +58,10 @@ func (api *API) Cves(request *CvesRequest) (*Cves, error) {
 	return request.cves(api.Cache)
 }
 
+func (api *API) Errata(request *ErrataRequest) (*Errata, error) {
+	return request.errata(api.Cache)
+}
+
 func (api *API) LoadCacheFromFile(cachePath string) error {
 	var err error
 	api.Cache, err = loadCache(cachePath, api.options)


### PR DESCRIPTION
There is `StringSlice` type because, according to the spec, some values in the request can be either string or []string. After a conversation with @MichaelMraka, I implemented a custom JSON parser that will always produce []string. This seems to be a better approach as opposed to generics shenanigans or so.