### PR TITLE
fix: get source pkg from installed nevra for unfixed cves

### DIFF
--- a/vmaas/cache.go
+++ b/vmaas/cache.go
@@ -25,9 +25,8 @@ type Cache struct {
 
 	ArchCompat map[ArchID]map[ArchID]bool
 
-	PackageDetails    map[PkgID]PackageDetail
-	Nevra2PkgID       map[Nevra]PkgID
-	NameID2SrcNameIDs map[NameID]map[NameID]struct{}
+	PackageDetails map[PkgID]PackageDetail
+	Nevra2PkgID    map[Nevra]PkgID
 
 	RepoIDs            []RepoID
 	RepoDetails        map[RepoID]RepoDetail

--- a/vmaas/load.go
+++ b/vmaas/load.go
@@ -325,7 +325,6 @@ func loadPkgDetails(c *Cache) {
 	id2pkdDetail := make(map[PkgID]PackageDetail, cnt)
 	nevra2id := make(map[Nevra]PkgID, cnt)
 	srcPkgID2PkgID := make(map[PkgID][]PkgID, cntSrc)
-	nameID2SrcNameIDs := make(map[NameID]map[NameID]struct{})
 	var pkgID PkgID
 	for rows.Next() {
 		var det PackageDetail
@@ -343,16 +342,6 @@ func loadPkgDetails(c *Cache) {
 			continue
 		}
 
-		var srcNameID NameID
-		row := sqlDB.QueryRow("SELECT name_id FROM package_detail WHERE id = ?", *det.SrcPkgID)
-		if err := row.Scan(&srcNameID); err != nil {
-			panic(err)
-		}
-		if _, ok := nameID2SrcNameIDs[det.NameID]; !ok {
-			nameID2SrcNameIDs[det.NameID] = make(map[NameID]struct{})
-		}
-		nameID2SrcNameIDs[det.NameID][srcNameID] = struct{}{}
-
 		_, ok := srcPkgID2PkgID[*det.SrcPkgID]
 		if !ok {
 			srcPkgID2PkgID[*det.SrcPkgID] = []PkgID{}
@@ -365,7 +354,6 @@ func loadPkgDetails(c *Cache) {
 	c.PackageDetails = id2pkdDetail
 	c.Nevra2PkgID = nevra2id
 	c.SrcPkgID2PkgID = srcPkgID2PkgID
-	c.NameID2SrcNameIDs = nameID2SrcNameIDs
 }
 
 func loadRepoDetails(c *Cache) { //nolint: funlen


### PR DESCRIPTION
we need to get source package from installed nevra not just from installed package name.
We are showing false positive unfixed cves for packages built from different sources. E.g. `bpftool` is built from `kernel` and `kernel-rt` source packages and we are showing the CVE reported for kernel-rt when regular kernel is used which is incorrect (CVE-2022-0516 for bpftool-0:4.18.0-553.30.1.el8_10.x86_64)
