### PR TITLE
feat: rewrite vmaas package_names/srpms endpoint in go

### DIFF
--- a/vmaas/cache.go
+++ b/vmaas/cache.go
@@ -279,3 +279,17 @@ func (c *Cache) nameID2ContentSetIDs(nameID NameID) []ContentSetID {
 func (c *Cache) contentSetIDs2Labels(csIDs []ContentSetID) []string {
 	return utils.ApplyMap(csIDs, c.ContentSetID2Label)
 }
+
+func (c *Cache) nameIDs2PackageNames(nameIDs []NameID) []string {
+	return utils.ApplyMap(nameIDs, c.ID2Packagename)
+}
+
+func (c *Cache) labels2ContentSetIDs(labels []string) map[ContentSetID]bool {
+	csIDs := make(map[ContentSetID]bool, len(labels))
+	for _, label := range labels {
+		if csID, found := c.Label2ContentSetID[label]; found {
+			csIDs[csID] = true
+		}
+	}
+	return csIDs
+}

--- a/vmaas/cache.go
+++ b/vmaas/cache.go
@@ -39,7 +39,8 @@ type Cache struct {
 	Label2ContentSetID map[string]ContentSetID
 	ContentSetID2Label map[ContentSetID]string
 
-	ContentSetID2PkgNameIDs map[ContentSetID][]NameID
+	ContentSetID2PkgNameIDs    map[ContentSetID][]NameID
+	SrcPkgNameID2ContentSetIDs map[NameID][]ContentSetID
 
 	ProductID2RepoIDs map[int][]RepoID
 	PkgID2RepoIDs     map[PkgID][]RepoID

--- a/vmaas/cache_test.go
+++ b/vmaas/cache_test.go
@@ -117,6 +117,22 @@ func TestNameID2ContentSetIDs(t *testing.T) {
 	assert.Equal(t, 3, len(csIDs))
 }
 
+func TestLabels2ContentSetIDs(t *testing.T) {
+	c := Cache{
+		Label2ContentSetID: map[string]ContentSetID{
+			"foo": 1,
+			"bar": 2,
+			"baz": 3,
+		},
+	}
+	labels := []string{"bar", "foo", "invalid"}
+	csIDs := c.labels2ContentSetIDs(labels)
+	assert.Equal(t, 2, len(csIDs))
+	assert.True(t, csIDs[1])
+	assert.True(t, csIDs[2])
+	assert.False(t, csIDs[3])
+}
+
 //nolint:funlen
 func mockCache() *Cache {
 	modifiedDate, _ := time.Parse(time.RFC3339, "2024-10-03T11:44:00+02:00")
@@ -147,11 +163,30 @@ func mockCache() *Cache {
 			"bash":        3,
 			"python-perf": 4,
 			"vim-common":  5,
+			"foo":         6,
+		},
+
+		SrcPkgNameID2ContentSetIDs: map[NameID][]ContentSetID{
+			6: {101, 103, 104},
+		},
+
+		ContentSetID2Label: map[ContentSetID]string{
+			101: "test_cs_01",
+			102: "test_cs_02",
+			103: "test_cs_03",
+			104: "test_cs_04",
+		},
+
+		Label2ContentSetID: map[string]ContentSetID{
+			"test_cs_01": 101,
+			"test_cs_02": 102,
+			"test_cs_03": 103,
+			"test_cs_04": 104,
 		},
 
 		ContentSetID2PkgNameIDs: map[ContentSetID][]NameID{
 			101: {1, 2},
-			102: {1, 2, 3},
+			102: {1, 2, 3, 6},
 			103: {2},
 			104: {},
 		},
@@ -166,6 +201,7 @@ func mockCache() *Cache {
 			{NameID: 3, EvrID: 3, ArchID: 1}: 4,
 			{NameID: 4, EvrID: 4, ArchID: 1}: 5,
 			{NameID: 5, EvrID: 5, ArchID: 1}: 6,
+			{NameID: 6}:                      42,
 		},
 
 		PkgID2RepoIDs: map[PkgID][]RepoID{

--- a/vmaas/load.go
+++ b/vmaas/load.go
@@ -24,8 +24,9 @@ var (
 
 var loadFuncs = []func(c *Cache){
 	loadPkgNames, loadUpdates, loadUpdatesIndex, loadEvrMaps, loadArchs, loadArchCompat, loadRepoDetails,
-	loadLabel2ContentSetID, loadContentSetID2PkgNameIDs, loadPkgRepos, loadErrata, loadPkgErratum, loadErrataRepoIDs,
-	loadCves, loadPkgErratumModule, loadModule2IDs, loadModuleRequires, loadDBChanges, loadString, loadOSReleaseDetails,
+	loadLabel2ContentSetID, loadContentSetID2PkgNameIDs, loadSrcPkgNameID2ContentSetIDs, loadPkgRepos, loadErrata,
+	loadPkgErratum, loadErrataRepoIDs, loadCves, loadPkgErratumModule, loadModule2IDs, loadModuleRequires,
+	loadDBChanges, loadString, loadOSReleaseDetails,
 	// CSAF
 	loadRepoCpes, loadContentSet2Cpes, loadCpeID2Label, loadCSAFCVE,
 }
@@ -473,6 +474,12 @@ func loadLabel2ContentSetID(c *Cache) {
 func loadContentSetID2PkgNameIDs(c *Cache) {
 	c.ContentSetID2PkgNameIDs = loadK2Vs[ContentSetID, NameID](
 		"content_set_pkg_name", "content_set_id,pkg_name_id", "ContentSetID2PkgNameIDs", false,
+	)
+}
+
+func loadSrcPkgNameID2ContentSetIDs(c *Cache) {
+	c.SrcPkgNameID2ContentSetIDs = loadK2Vs[NameID, ContentSetID](
+		"content_set_src_pkg_name", "src_pkg_name_id,content_set_id", "SrcPkgNameID2ContentSetIDs", false,
 	)
 }
 

--- a/vmaas/srpm_pkg_names.go
+++ b/vmaas/srpm_pkg_names.go
@@ -1,0 +1,83 @@
+package vmaas
+
+import (
+	"slices"
+
+	"github.com/pkg/errors"
+	"github.com/redhatinsights/vmaas-lib/vmaas/utils"
+)
+
+type RPMData map[string]map[string][]string
+
+type SRPMPkgNames struct {
+	Names      RPMData `json:"srpm_name_list"` // TODO: use `omitzero` from go1.24
+	LastChange string  `json:"last_change"`
+}
+
+// GetSrcPkgPkgNameIDs returns package names of the packages under the source package with srcNameID.
+func (c *Cache) getSrcPkgPkgNameIDs(srcNameID NameID) map[NameID]bool {
+	pkgNameIDs := map[NameID]bool{}
+	for nevra, pkgID := range c.Nevra2PkgID {
+		pkgIDs, found := c.SrcPkgID2PkgID[pkgID]
+		if nevra.NameID != srcNameID || !found {
+			continue
+		}
+		for _, pid := range pkgIDs {
+			nameID := c.PackageDetails[pid].NameID
+			pkgNameIDs[nameID] = true
+		}
+	}
+	return pkgNameIDs
+}
+
+func (c *Cache) getRPMData(srpmNames []string, contentSets []string) RPMData {
+	csMap := c.labels2ContentSetIDs(contentSets)
+	isDuplicate := make(map[string]bool, len(srpmNames))
+	rpmData := make(RPMData, len(srpmNames))
+	for _, srpm := range srpmNames {
+		srcNameID, found := c.Packagename2ID[srpm]
+		if !found || isDuplicate[srpm] {
+			continue
+		}
+
+		csIDs := c.nameID2ContentSetIDs(srcNameID)
+		csIDs = append(csIDs, c.SrcPkgNameID2ContentSetIDs[srcNameID]...)
+		if len(contentSets) != 0 {
+			csIDs = utils.Intersection(csIDs, csMap)
+		}
+
+		pkgNameIDs := c.getSrcPkgPkgNameIDs(srcNameID)
+		if len(pkgNameIDs) == 0 {
+			continue
+		}
+
+		filteredNames := make(map[string][]string, len(csIDs))
+		for _, id := range csIDs {
+			label := c.ContentSetID2Label[id]
+			nameIDs := utils.Intersection(c.ContentSetID2PkgNameIDs[id], pkgNameIDs)
+			names := c.nameIDs2PackageNames(nameIDs)
+			slices.Sort(names)
+			filteredNames[label] = names
+		}
+
+		rpmData[srpm] = filteredNames
+		isDuplicate[srpm] = true
+	}
+	return rpmData
+}
+
+func (req *SRPMPkgNamesRequest) srpmPkgNames(c *Cache) (*SRPMPkgNames, error) { // TODO: implement opts
+	if req.SRPMNames == nil {
+		return &SRPMPkgNames{}, errors.Wrap(ErrProcessingInput, "'srpm_name_list' is a required property")
+	}
+
+	if len(req.SRPMNames) == 0 {
+		return &SRPMPkgNames{}, nil
+	}
+
+	res := SRPMPkgNames{
+		Names:      c.getRPMData(req.SRPMNames, req.ContentSets),
+		LastChange: c.DBChange.LastChange,
+	}
+	return &res, nil
+}

--- a/vmaas/srpm_pkg_names_test.go
+++ b/vmaas/srpm_pkg_names_test.go
@@ -1,0 +1,42 @@
+package vmaas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSrcPkgPkgNameIDs(t *testing.T) {
+	c := mockCache()
+	nameIDs := c.getSrcPkgPkgNameIDs(6)
+	assert.Equal(t, 2, len(nameIDs))
+	assert.True(t, nameIDs[1])
+	assert.True(t, nameIDs[2])
+}
+
+func TestGetRPMData(t *testing.T) {
+	c := mockCache()
+	names := []string{"foo"}
+
+	data := c.getRPMData(names, []string{})
+	assert.Equal(t, 1, len(data))
+	assert.Equal(t, 4, len(data["foo"]))
+
+	contentSets := []string{"test_cs_02", "test_cs_03"}
+	data = c.getRPMData(names, contentSets)
+	assert.Equal(t, 1, len(data))
+	assert.Equal(t, 2, len(data["foo"]))
+}
+
+func TestSRPMPkgNames(t *testing.T) {
+	// missing srpm name list
+	req := &SRPMPkgNamesRequest{}
+	_, err := req.srpmPkgNames(nil)
+	assert.Error(t, err)
+
+	// empty srpm name list
+	req = &SRPMPkgNamesRequest{SRPMNames: []string{}}
+	res, err := req.srpmPkgNames(nil)
+	assert.NoError(t, err)
+	assert.Empty(t, res)
+}

--- a/vmaas/types.go
+++ b/vmaas/types.go
@@ -194,6 +194,11 @@ type RPMPkgNamesRequest struct {
 	ContentSets []string `json:"content_set_list"`
 }
 
+type SRPMPkgNamesRequest struct {
+	SRPMNames   []string `json:"srpm_name_list"`
+	ContentSets []string `json:"content_set_list"`
+}
+
 type Update struct {
 	Package     string `json:"package"`
 	PackageName string `json:"package_name"`

--- a/vmaas/vmaas.go
+++ b/vmaas/vmaas.go
@@ -86,6 +86,10 @@ func (api *API) RPMPkgNames(request *RPMPkgNamesRequest) (*RPMPkgNames, error) {
 	return request.rpmPkgNames(api.Cache)
 }
 
+func (api *API) SRPMPkgNames(request *SRPMPkgNamesRequest) (*SRPMPkgNames, error) {
+	return request.srpmPkgNames(api.Cache)
+}
+
 func (api *API) OSVulnerabilityReport() (*VulnerabilityReport, error) {
 	return vulnerabilityReport(api.Cache, api.options)
 }


### PR DESCRIPTION
Cannot use `omitempty` for the fields in response like in `/rpms`, because it causes some tests to fail