### PR TITLE
feat: load release graphs

### DIFF
--- a/vmaas/cache.go
+++ b/vmaas/cache.go
@@ -69,6 +69,7 @@ type Cache struct {
 	CSAFCVEs               map[CpeIDNameID]map[CSAFProduct]CSAFCVEs
 	CSAFCVEProduct2Erratum map[CSAFCVEProduct]string
 	CSAFProduct2ID         map[CSAFProduct]CSAFProductID
+	ReleaseGraphs          []ReleaseGraph
 
 	OSReleaseDetails map[int]OSReleaseDetail
 }

--- a/vmaas/releasegraph.go
+++ b/vmaas/releasegraph.go
@@ -1,0 +1,91 @@
+package vmaas
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type ReleaseNode struct {
+	VariantSuffix string
+	Type          string
+	CPEs          []string
+	Children      []*ReleaseNode
+	Parent        *ReleaseNode
+}
+
+type ReleaseGraph struct {
+	GetByVariant map[string]*ReleaseNode
+}
+
+type ReleseGraphRaw struct {
+	Nodes map[string]struct {
+		Type string   `json:"type"`
+		CPEs []string `json:"cpes"`
+	} `json:"nodes"`
+	Edges map[string][]string `json:"edges"`
+}
+
+// Get suffix from release name mappable to product variant suffix
+func getVariantSuffix(variant string) (string, error) {
+	// we are interested only in rhel release name suffix
+	// that we can directly map to rhel product variant
+	// and replace "+" with "." because product variants don't contain "+"
+	// example:
+	// 	release name:     RHEL-9.2.0.Z.MAIN+EUS
+	//  product variant:  Appstream-9.2.0.Z.MAIN.EUS
+	splitted := strings.SplitN(variant, "-", 2)
+	if len(splitted) != 2 {
+		return "", errors.New("release name without '-'")
+	}
+	return strings.ReplaceAll(splitted[1], "+", "."), nil
+}
+
+// Build the ReleaseGraph tree structure
+func (raw *ReleseGraphRaw) BuildGraph() *ReleaseGraph {
+	g := &ReleaseGraph{GetByVariant: make(map[string]*ReleaseNode)}
+
+	// Create all nodes
+	for id, data := range raw.Nodes {
+		variantSuffix, err := getVariantSuffix(id)
+		if err != nil {
+			continue
+		}
+		g.GetByVariant[variantSuffix] = &ReleaseNode{
+			VariantSuffix: variantSuffix,
+			Type:          data.Type,
+			CPEs:          data.CPEs,
+		}
+	}
+
+	// Link parent/children based on edges
+	for fromID, toIDs := range raw.Edges {
+		fromVariant, err := getVariantSuffix(fromID)
+		if err != nil {
+			continue
+		}
+		parent := g.GetByVariant[fromVariant]
+		for _, toID := range toIDs {
+			toVariant, err := getVariantSuffix(toID)
+			if err != nil {
+				continue
+			}
+			child := g.GetByVariant[toVariant]
+			parent.Children = append(parent.Children, child)
+			child.Parent = parent
+		}
+	}
+
+	return g
+}
+
+// Get all parent nodes (ancestors) of a node by a node id - product variant suffix
+func (g *ReleaseGraph) GetAncestors(variant string) []*ReleaseNode {
+	var ancestors []*ReleaseNode
+	node := g.GetByVariant[variant]
+	for node != nil && node.Parent != nil {
+		ancestors = append(ancestors, node.Parent)
+		node = node.Parent
+	}
+	return ancestors
+}

--- a/vmaas/releasegraph_test.go
+++ b/vmaas/releasegraph_test.go
@@ -1,0 +1,43 @@
+package vmaas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testJSON = `{
+  "nodes": {
+    "RHEL-8.0.0": { "type": "main", "cpes": ["cpe:/a:redhat:enterprise_linux:8::appstream"] },
+    "RHEL-8.0.0.Z": { "type": "main", "cpes": ["cpe:/a:redhat:enterprise_linux:8::appstream"] },
+    "RHEL-8.0.1": { "type": "main", "cpes": ["cpe:/a:redhat:enterprise_linux:8::appstream"] }
+  },
+  "edges": {
+    "RHEL-8.0.0": ["RHEL-8.0.0.Z"],
+    "RHEL-8.0.0.Z": ["RHEL-8.0.1"]
+  }
+}`
+
+func TestBuildGraphAndAncestors(t *testing.T) {
+	var raw ReleseGraphRaw
+	err := json.Unmarshal([]byte(testJSON), &raw)
+	require.NoError(t, err)
+
+	graph := raw.BuildGraph()
+
+	require.Len(t, graph.GetByVariant, 3)
+
+	node := graph.GetByVariant["8.0.0.Z"]
+	require.NotNil(t, node)
+
+	assert.Equal(t, "8.0.0", node.Parent.VariantSuffix)
+	assert.Len(t, node.Children, 1)
+	assert.Equal(t, "8.0.1", node.Children[0].VariantSuffix)
+
+	ancestors := graph.GetAncestors("8.0.1")
+	require.Len(t, ancestors, 2)
+	assert.Equal(t, "8.0.0.Z", ancestors[0].VariantSuffix)
+	assert.Equal(t, "8.0.0", ancestors[1].VariantSuffix)
+}


### PR DESCRIPTION
- `ReleaseGraph` tree structure allows O(1) lookup by product variant suffix
- `ReleaseNode` keeps pointers to Parent node and Children nodes for tree
  navigation
- `GetAncestors` returns all ancestors of a given ReleaseNode, it will be
  used to find if a CVE is fixed in previous/parent product variants