### PR TITLE
feat: use product variants to fix cves from newer releasever

### DIFF
--- a/vmaas/cache.go
+++ b/vmaas/cache.go
@@ -67,7 +67,7 @@ type Cache struct {
 
 	// CSAF
 	CSAFProductStatus      map[int]string
-	CSAFCVEs               map[CpeIDNameID]map[CSAFProduct]CSAFCVEs
+	CSAFCVEs               map[VariantSuffix]map[CpeIDNameID]map[CSAFProduct]CSAFCVEs
 	CSAFCVEProduct2Erratum map[CSAFCVEProduct]string
 	CSAFProduct2ID         map[CSAFProduct]CSAFProductID
 	ReleaseGraphs          []ReleaseGraph

--- a/vmaas/cache.go
+++ b/vmaas/cache.go
@@ -63,6 +63,7 @@ type Cache struct {
 	ContentSetID2CpeIDs map[ContentSetID][]CpeID
 	RepoID2CpeIDs       map[RepoID][]CpeID
 	CpeID2Label         map[CpeID]CpeLabel
+	CpeLabel2ID         map[CpeLabel]CpeID
 
 	// CSAF
 	CSAFProductStatus      map[int]string

--- a/vmaas/common.go
+++ b/vmaas/common.go
@@ -39,14 +39,18 @@ type repoIDReleasevers struct {
 	newerReleasever   RepoID
 }
 
+type variantCPE struct {
+	VariantSuffix VariantSuffix
+	CpeID         CpeID
+}
+
 type ProcessedRequest struct {
-	Updates             *Updates
-	Packages            []NevraString
-	Cpes                []CpeID
-	NewerReleaseverCpes []CpeID
-	ContentSetsCpes     []CpeID
-	ContentSets         []ContentSetID
-	OriginalRequest     *Request
+	Updates               *Updates
+	Packages              []NevraString
+	VariantCpes           []variantCPE
+	NewerVariantCpes      []variantCPE
+	ContentSetVariantCpes []variantCPE
+	OriginalRequest       *Request
 }
 
 func (r *ProcessedRequest) evaluateRepositories(c *Cache, opts *options) *Updates {

--- a/vmaas/cpe.go
+++ b/vmaas/cpe.go
@@ -3,6 +3,8 @@ package vmaas
 import (
 	"slices"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/redhatinsights/vmaas-lib/vmaas/utils"
 )
 
@@ -45,4 +47,95 @@ func getMatchingCpes(cpeID2Label map[CpeID]CpeLabel, inputCpes []CpeLabel) []Cpe
 		}
 	}
 	return res
+}
+
+func releaseNodesFromCpes(c *Cache, cpes []CpeLabel) []*ReleaseNode {
+	res := make([]*ReleaseNode, 0)
+	for _, cpe := range cpes {
+		for _, graph := range c.ReleaseGraphs {
+			nodes, ok := graph.GetByCpe[cpe]
+			if !ok {
+				continue
+			}
+			res = append(res, nodes...)
+		}
+	}
+	return res
+}
+
+func releaseNodes2VariantCpes(c *Cache, nodes []*ReleaseNode, except map[variantCPE]bool) []variantCPE {
+	variantCpes := make([]variantCPE, 0)
+	seen := make(map[variantCPE]bool)
+	for _, node := range nodes {
+		for _, nodeCpe := range node.CPEs {
+			cpeID, ok := c.CpeLabel2ID[nodeCpe]
+			if !ok {
+				utils.LogInfo("cpe", nodeCpe, "Unknown CPE")
+			}
+			varCpe := variantCPE{
+				VariantSuffix: node.VariantSuffix,
+				CpeID:         cpeID,
+			}
+			if !except[varCpe] && !seen[varCpe] {
+				variantCpes = append(variantCpes, varCpe)
+				seen[varCpe] = true
+			}
+		}
+	}
+	return variantCpes
+}
+
+func cpes2variantCpes(c *Cache, cpes []CpeLabel, except []variantCPE) []variantCPE {
+	ancestorNodes := make([]*ReleaseNode, 0)
+	nodes := releaseNodesFromCpes(c, cpes)
+	variantCpes := releaseNodes2VariantCpes(c, nodes, nil)
+
+	for _, node := range nodes {
+		ancestors := node.GetAncestors()
+		ancestorNodes = append(ancestorNodes, ancestors...)
+	}
+
+	exceptMap := make(map[variantCPE]bool, len(except))
+	for _, x := range except {
+		exceptMap[x] = true
+	}
+
+	ancestorVariantCpes := releaseNodes2VariantCpes(c, ancestorNodes, exceptMap)
+	variantCpes = append(variantCpes, ancestorVariantCpes...)
+
+	slices.SortStableFunc(variantCpes, func(x, y variantCPE) int {
+		verX, errx := version.NewVersion(string(x.VariantSuffix))
+		verY, erry := version.NewVersion(string(x.VariantSuffix))
+		switch {
+		case errx != nil && erry != nil:
+			return 0
+		case errx != nil:
+			return -1
+		case erry != nil:
+			return 1
+		}
+		return verX.Compare(verY)
+	})
+	return variantCpes
+}
+
+func repos2cpes(c *Cache, repoIDs []RepoID) []CpeLabel {
+	repoCpes := make([]CpeID, 0)
+	for _, repoID := range repoIDs {
+		if cpes, has := c.RepoID2CpeIDs[repoID]; has {
+			repoCpes = append(repoCpes, cpes...)
+		}
+	}
+	return c.cpeIDs2Labels(repoCpes)
+}
+
+func contentSets2cpes(c *Cache, csIDs []ContentSetID) []CpeLabel {
+	csCpes := make([]CpeID, 0)
+	for _, csID := range csIDs {
+		if cpes, has := c.ContentSetID2CpeIDs[csID]; has {
+			csCpes = append(csCpes, cpes...)
+		}
+	}
+
+	return c.cpeIDs2Labels(csCpes)
 }

--- a/vmaas/cpe.go
+++ b/vmaas/cpe.go
@@ -1,0 +1,48 @@
+package vmaas
+
+import (
+	"slices"
+
+	"github.com/redhatinsights/vmaas-lib/vmaas/utils"
+)
+
+func getMatchingCpes(cpeID2Label map[CpeID]CpeLabel, inputCpes []CpeLabel) []CpeLabel {
+	type Cpe struct {
+		Label  CpeLabel
+		Parsed ParsedCpe
+	}
+	cpes := make([]Cpe, 0)
+	if len(inputCpes) > 0 {
+		for _, cpeLabel := range cpeID2Label {
+			cpeLabelParsed, err := cpeLabel.Parse()
+			if err != nil {
+				utils.LogWarn("cpe", cpeLabel, "Cannot parse")
+				continue
+			}
+			for _, inputCpe := range inputCpes {
+				repoCpeParsed, err := inputCpe.Parse()
+				if err != nil {
+					utils.LogWarn("cpe", inputCpe, "Cannot parse")
+					continue
+				}
+				if cpeLabelParsed.Match(repoCpeParsed) {
+					cpes = append(cpes, Cpe{cpeLabel, *cpeLabelParsed})
+					break
+				}
+			}
+		}
+	}
+	slices.SortFunc(cpes, func(x, y Cpe) int {
+		return x.Parsed.CmpByVersion(&y.Parsed)
+	})
+
+	res := make([]CpeLabel, 0, len(cpes))
+	seen := make(map[CpeLabel]bool, len(cpes))
+	for _, cpe := range cpes {
+		if !seen[cpe.Label] {
+			res = append(res, cpe.Label)
+			seen[cpe.Label] = true
+		}
+	}
+	return res
+}

--- a/vmaas/cpe.go
+++ b/vmaas/cpe.go
@@ -105,7 +105,7 @@ func cpes2variantCpes(c *Cache, cpes []CpeLabel, except []variantCPE) []variantC
 
 	slices.SortStableFunc(variantCpes, func(x, y variantCPE) int {
 		verX, errx := version.NewVersion(string(x.VariantSuffix))
-		verY, erry := version.NewVersion(string(x.VariantSuffix))
+		verY, erry := version.NewVersion(string(y.VariantSuffix))
 		switch {
 		case errx != nil && erry != nil:
 			return 0

--- a/vmaas/load.go
+++ b/vmaas/load.go
@@ -1011,7 +1011,7 @@ func loadReleaseGraphs(c *Cache) {
 	cnt := getCount("release_graph", "*")
 	graphs := make([]ReleaseGraph, 0, cnt)
 	for rows.Next() {
-		var rawGraph ReleseGraphRaw
+		var rawGraph ReleaseGraphRaw
 		var raw string
 		if err := rows.Scan(&raw); err != nil {
 			panic(err)

--- a/vmaas/load.go
+++ b/vmaas/load.go
@@ -886,7 +886,7 @@ func productsByStatus(
 	}
 }
 
-func loadCSAFCVE(c *Cache) {
+func loadCSAFCVE(c *Cache) { //nolint: funlen
 	loadCSAFProductStatus(c) // Load statuses before other CSAF load functions
 
 	defer utils.TimeTrack(time.Now(), "CSAF CVEs")
@@ -1021,7 +1021,7 @@ func loadReleaseGraphs(c *Cache) {
 			panic(err)
 		}
 
-		graph := rawGraph.BuildGraph(c.CpeID2Label, c.CpeLabel2ID)
+		graph := rawGraph.BuildGraph(c.CpeID2Label)
 		graphs = append(graphs, *graph)
 	}
 	c.ReleaseGraphs = graphs

--- a/vmaas/load.go
+++ b/vmaas/load.go
@@ -29,7 +29,7 @@ var loadFuncs = []func(c *Cache){
 	loadPkgErratum, loadErratumRepoIDs, loadCves, loadPkgErratumModule, loadModule2IDs, loadModuleRequires,
 	loadDBChanges, loadString, loadOSReleaseDetails,
 	// CSAF
-	loadRepoCpes, loadContentSet2Cpes, loadCpeID2Label, loadCSAFCVE, loadReleaseGraphs,
+	loadRepoCpes, loadContentSet2Cpes, loadCpeID2Label, loadCpeLabel2ID, loadCSAFCVE, loadReleaseGraphs,
 }
 
 func openDB(path string) error {
@@ -833,6 +833,10 @@ func loadContentSet2Cpes(c *Cache) {
 
 func loadCpeID2Label(c *Cache) {
 	c.CpeID2Label = loadK2V[CpeID, CpeLabel]("cpe", "id,label", "CpeID2Label")
+}
+
+func loadCpeLabel2ID(c *Cache) {
+	c.CpeLabel2ID = loadK2V[CpeLabel, CpeID]("cpe", "label,id", "CpeLabel2ID")
 }
 
 func loadCSAFProductStatus(c *Cache) {

--- a/vmaas/releasegraph.go
+++ b/vmaas/releasegraph.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ReleaseNode struct {
-	VariantSuffix string
+	VariantSuffix VariantSuffix
 	Type          string
 	CPEs          []string
 	Children      []*ReleaseNode
@@ -15,7 +15,7 @@ type ReleaseNode struct {
 }
 
 type ReleaseGraph struct {
-	GetByVariant map[string]*ReleaseNode
+	GetByVariant map[VariantSuffix]*ReleaseNode
 }
 
 type ReleseGraphRaw struct {
@@ -27,7 +27,7 @@ type ReleseGraphRaw struct {
 }
 
 // Get suffix from release name mappable to product variant suffix
-func getVariantSuffix(variant string) (string, error) {
+func getVariantSuffix(variant string) (VariantSuffix, error) {
 	// we are interested only in rhel release name suffix
 	// that we can directly map to rhel product variant
 	// and replace "+" with "." because product variants don't contain "+"
@@ -38,12 +38,12 @@ func getVariantSuffix(variant string) (string, error) {
 	if len(splitted) != 2 {
 		return "", errors.New("release name without '-'")
 	}
-	return strings.ReplaceAll(splitted[1], "+", "."), nil
+	return VariantSuffix(strings.ReplaceAll(splitted[1], "+", ".")), nil
 }
 
 // Build the ReleaseGraph tree structure
 func (raw *ReleseGraphRaw) BuildGraph() *ReleaseGraph {
-	g := &ReleaseGraph{GetByVariant: make(map[string]*ReleaseNode)}
+	g := &ReleaseGraph{GetByVariant: make(map[VariantSuffix]*ReleaseNode)}
 
 	// Create all nodes
 	for id, data := range raw.Nodes {
@@ -80,7 +80,7 @@ func (raw *ReleseGraphRaw) BuildGraph() *ReleaseGraph {
 }
 
 // Get all parent nodes (ancestors) of a node by a node id - product variant suffix
-func (g *ReleaseGraph) GetAncestors(variant string) []*ReleaseNode {
+func (g *ReleaseGraph) GetAncestors(variant VariantSuffix) []*ReleaseNode {
 	var ancestors []*ReleaseNode
 	node := g.GetByVariant[variant]
 	for node != nil && node.Parent != nil {

--- a/vmaas/releasegraph.go
+++ b/vmaas/releasegraph.go
@@ -19,7 +19,7 @@ type ReleaseGraph struct {
 	GetByCpe     map[CpeLabel][]*ReleaseNode
 }
 
-type ReleseGraphRaw struct {
+type ReleaseGraphRaw struct {
 	Nodes map[string]struct {
 		Type string     `json:"type"`
 		CPEs []CpeLabel `json:"cpes"`
@@ -43,7 +43,7 @@ func getVariantSuffix(variant string) (VariantSuffix, error) {
 }
 
 // Build the ReleaseGraph tree structure
-func (raw *ReleseGraphRaw) BuildGraph(cpeID2Label map[CpeID]CpeLabel, cpeLabel2ID map[CpeLabel]CpeID) *ReleaseGraph {
+func (raw *ReleaseGraphRaw) BuildGraph(cpeID2Label map[CpeID]CpeLabel, cpeLabel2ID map[CpeLabel]CpeID) *ReleaseGraph {
 	g := &ReleaseGraph{
 		GetByVariant: make(map[VariantSuffix]*ReleaseNode),
 		GetByCpe:     make(map[CpeLabel][]*ReleaseNode),

--- a/vmaas/releasegraph.go
+++ b/vmaas/releasegraph.go
@@ -43,7 +43,7 @@ func getVariantSuffix(variant string) (VariantSuffix, error) {
 }
 
 // Build the ReleaseGraph tree structure
-func (raw *ReleaseGraphRaw) BuildGraph(cpeID2Label map[CpeID]CpeLabel, cpeLabel2ID map[CpeLabel]CpeID) *ReleaseGraph {
+func (raw *ReleaseGraphRaw) BuildGraph(cpeID2Label map[CpeID]CpeLabel) *ReleaseGraph {
 	g := &ReleaseGraph{
 		GetByVariant: make(map[VariantSuffix]*ReleaseNode),
 		GetByCpe:     make(map[CpeLabel][]*ReleaseNode),

--- a/vmaas/releasegraph_test.go
+++ b/vmaas/releasegraph_test.go
@@ -23,14 +23,13 @@ const testJSON = `{
 func TestBuildGraphAndAncestors(t *testing.T) {
 	c := &Cache{
 		CpeID2Label: map[CpeID]CpeLabel{1: "cpe:/a:redhat:enterprise_linux:8::appstream"},
-		CpeLabel2ID: map[CpeLabel]CpeID{"cpe:/a:redhat:enterprise_linux:8::appstream": 1},
 	}
 
 	var raw ReleaseGraphRaw
 	err := json.Unmarshal([]byte(testJSON), &raw)
 	require.NoError(t, err)
 
-	graph := raw.BuildGraph(c.CpeID2Label, c.CpeLabel2ID)
+	graph := raw.BuildGraph(c.CpeID2Label)
 
 	require.Len(t, graph.GetByVariant, 3)
 

--- a/vmaas/releasegraph_test.go
+++ b/vmaas/releasegraph_test.go
@@ -21,7 +21,7 @@ const testJSON = `{
 }`
 
 func TestBuildGraphAndAncestors(t *testing.T) {
-	var raw ReleseGraphRaw
+	var raw ReleaseGraphRaw
 	err := json.Unmarshal([]byte(testJSON), &raw)
 	require.NoError(t, err)
 

--- a/vmaas/releasegraph_test.go
+++ b/vmaas/releasegraph_test.go
@@ -21,23 +21,28 @@ const testJSON = `{
 }`
 
 func TestBuildGraphAndAncestors(t *testing.T) {
+	c := &Cache{
+		CpeID2Label: map[CpeID]CpeLabel{1: "cpe:/a:redhat:enterprise_linux:8::appstream"},
+		CpeLabel2ID: map[CpeLabel]CpeID{"cpe:/a:redhat:enterprise_linux:8::appstream": 1},
+	}
+
 	var raw ReleaseGraphRaw
 	err := json.Unmarshal([]byte(testJSON), &raw)
 	require.NoError(t, err)
 
-	graph := raw.BuildGraph()
+	graph := raw.BuildGraph(c.CpeID2Label, c.CpeLabel2ID)
 
 	require.Len(t, graph.GetByVariant, 3)
 
 	node := graph.GetByVariant["8.0.0.Z"]
 	require.NotNil(t, node)
 
-	assert.Equal(t, "8.0.0", node.Parent.VariantSuffix)
+	assert.Equal(t, VariantSuffix("8.0.0"), node.Parent.VariantSuffix)
 	assert.Len(t, node.Children, 1)
-	assert.Equal(t, "8.0.1", node.Children[0].VariantSuffix)
+	assert.Equal(t, VariantSuffix("8.0.1"), node.Children[0].VariantSuffix)
 
 	ancestors := graph.GetAncestors("8.0.1")
 	require.Len(t, ancestors, 2)
-	assert.Equal(t, "8.0.0.Z", ancestors[0].VariantSuffix)
-	assert.Equal(t, "8.0.0", ancestors[1].VariantSuffix)
+	assert.Equal(t, VariantSuffix("8.0.0.Z"), ancestors[0].VariantSuffix)
+	assert.Equal(t, VariantSuffix("8.0.0"), ancestors[1].VariantSuffix)
 }

--- a/vmaas/vulnerabilities_test.go
+++ b/vmaas/vulnerabilities_test.go
@@ -185,12 +185,18 @@ func TestManualCvesNewerRelease(t *testing.T) {
 	productCveFixed := CSAFProduct{CpeID: 1, PackageNameID: 1, PackageID: 1, VariantSuffix: DefaultVariantSuffix}
 	productCve1 := CSAFProduct{CpeID: 1, PackageNameID: 1, PackageID: 2, VariantSuffix: DefaultVariantSuffix}
 	productCve3 := CSAFProduct{CpeID: 1, PackageNameID: 1, PackageID: 5, VariantSuffix: DefaultVariantSuffix}
-	productCveFixedNewer := CSAFProduct{CpeID: 2, PackageNameID: 1, PackageID: 3, ModuleStream: ms,
-		VariantSuffix: DefaultVariantSuffix}
-	productCve1Newer := CSAFProduct{CpeID: 2, PackageNameID: 1, PackageID: 4, ModuleStream: ms,
-		VariantSuffix: DefaultVariantSuffix}
-	productCve2Newer := CSAFProduct{CpeID: 2, PackageNameID: 1, PackageID: 5, ModuleStream: ms,
-		VariantSuffix: DefaultVariantSuffix}
+	productCveFixedNewer := CSAFProduct{
+		CpeID: 2, PackageNameID: 1, PackageID: 3, ModuleStream: ms,
+		VariantSuffix: DefaultVariantSuffix,
+	}
+	productCve1Newer := CSAFProduct{
+		CpeID: 2, PackageNameID: 1, PackageID: 4, ModuleStream: ms,
+		VariantSuffix: DefaultVariantSuffix,
+	}
+	productCve2Newer := CSAFProduct{
+		CpeID: 2, PackageNameID: 1, PackageID: 5, ModuleStream: ms,
+		VariantSuffix: DefaultVariantSuffix,
+	}
 	currentReleaseCPE := CpeLabel("cpe:/o:redhat:rhel_eus:8.6")
 	newerReleaseCPE := CpeLabel("cpe:/o:redhat:rhel_eus:8.8")
 	c := Cache{


### PR DESCRIPTION
- use product variants for csaf vex evaluation
- rely on release graphs, we will not find all matching CPEs for products not in the graph, such as RHEL 6 or RHEL 7. RHEL 6 and RHEL 7 won't get any CVEs from VEX
- get fixed CVEs by looking at current product variant and all ancestors
- get CVEs fixed in newer version by looking at newer release CPEs, and get product variants from them, including it's ancestors excluding variant found for current product version
- thanks to ancestor product variant we can now find unfixed CVEs for E4S/EUS/AUS/TUS
- another change is that previously we did match only CPEs with correct Edition - e.g. when customer had only `rhel-8-for-x86_64-appstream-e4s-rpms` we would look only at `:appstream` CPEs (or any other matching CPEs) now we get CPEs from release graph and we will look for results also in different Editions i.e `:highavailability`, `:baseos`, `:hfv`, `:sap`, etc. This should provide better scanning for CVEs in not enabled repos related to the product