### PR TITLE
fix: resolve missing field in response without rpm names

### DIFF
--- a/vmaas/rpm_pkg_names.go
+++ b/vmaas/rpm_pkg_names.go
@@ -11,8 +11,8 @@ import (
 type ContentData map[string][]string
 
 type RPMPkgNames struct {
-	Names      ContentData `json:"rpm_name_list,omitempty"` // TODO: use `omitzero` from go1.24
-	LastChange time.Time   `json:"last_change,omitempty"`
+	Names      ContentData `json:"rpm_name_list"` // TODO: use `omitzero` from go1.24
+	LastChange time.Time   `json:"last_change"`
 }
 
 func (c *Cache) getContentData(rpmNames []string, contentSets []string) ContentData {


### PR DESCRIPTION
RHINENG-18221

This change unifies behavior of `/package_names/rpms` and `/package_names/srpms`