### PR TITLE
fix(csaf): reduce memory usage

### DIFF
--- a/vmaas/common.go
+++ b/vmaas/common.go
@@ -39,18 +39,16 @@ type repoIDReleasevers struct {
 	newerReleasever   RepoID
 }
 
-type variantCPE struct {
-	VariantSuffix VariantSuffix
-	CpeID         CpeID
-}
-
 type ProcessedRequest struct {
-	Updates               *Updates
-	Packages              []NevraString
-	VariantCpes           []variantCPE
-	NewerVariantCpes      []variantCPE
-	ContentSetVariantCpes []variantCPE
-	OriginalRequest       *Request
+	Updates            *Updates
+	Packages           []NevraString
+	Variants           []VariantSuffix
+	NewerVariants      []VariantSuffix
+	ContentSetVariants []VariantSuffix
+	Cpes               []CpeID
+	NewerCpes          []CpeID
+	ContentSetCpes     []CpeID
+	OriginalRequest    *Request
 }
 
 func (r *ProcessedRequest) evaluateRepositories(c *Cache, opts *options) *Updates {

--- a/vmaas/cpe.go
+++ b/vmaas/cpe.go
@@ -3,7 +3,6 @@ package vmaas
 import (
 	"slices"
 
-	"github.com/hashicorp/go-version"
 	"github.com/redhatinsights/vmaas-lib/vmaas/utils"
 )
 
@@ -111,17 +110,7 @@ func cpes2variantsCpes(c *Cache, cpes []CpeLabel, exceptVariants []VariantSuffix
 	cpeIDs = append(cpeIDs, ancestorCpes...)
 
 	slices.SortStableFunc(variants, func(x, y VariantSuffix) int {
-		verX, errx := version.NewVersion(string(x))
-		verY, erry := version.NewVersion(string(y))
-		switch {
-		case errx != nil && erry != nil:
-			return 0
-		case errx != nil:
-			return -1
-		case erry != nil:
-			return 1
-		}
-		return verX.Compare(verY)
+		return x.Compare(&y)
 	})
 	slices.Sort(cpeIDs)
 	return variants, cpeIDs

--- a/vmaas/types.go
+++ b/vmaas/types.go
@@ -635,3 +635,44 @@ type CveIDString struct {
 	ID     CVEID
 	String string
 }
+
+// Split variant into slice of version numbers followed by string
+func (x *VariantSuffix) Split() ([]string, string) {
+	if x == nil {
+		return nil, ""
+	}
+	// variant suffix should consist of 3 numbers separated by "."
+	// followed by strings with dots
+	splitted := strings.SplitN(string(*x), ".", 4)
+	if len(splitted) <= 3 {
+		// we always want 4 items so append "0"
+		for i := 0; i < 4-len(splitted); i++ {
+			splitted = append(splitted, "0")
+		}
+	}
+	return splitted[:3], splitted[3]
+}
+
+// Compare compares this variant to another variant.
+// Returns -1, 0, or 1 if this variant is smaller, equal, or larger than the other variant.
+func (x *VariantSuffix) Compare(y *VariantSuffix) int {
+	switch {
+	case x == y:
+		return 0
+	case x == nil:
+		return -1
+	case y == nil:
+		return 1
+	case *x == *y:
+		return 0
+	}
+
+	xVersion, xRest := x.Split()
+	yVersion, yRest := y.Split()
+
+	cmp := slices.Compare(xVersion, yVersion)
+	if cmp == 0 {
+		cmp = strings.Compare(xRest, yRest)
+	}
+	return cmp
+}

--- a/vmaas/vulnerabilities.go
+++ b/vmaas/vulnerabilities.go
@@ -285,15 +285,17 @@ func (r *ProcessedRequest) processRepos(c *Cache) {
 	newerReleaseverCpes := repos2cpes(c, newerReleaseverRepoIDs)
 	newerVariants, newerCpes := cpes2variantsCpes(c, newerReleaseverCpes, variants)
 
-	csCpes := contentSets2cpes(c, contentSetIDs)
-	csVariants, csCpeIDs := cpes2variantsCpes(c, csCpes, nil)
+	if len(cpes) == 0 {
+		csCpes := contentSets2cpes(c, contentSetIDs)
+		csVariants, csCpeIDs := cpes2variantsCpes(c, csCpes, nil)
+		r.ContentSetCpes = csCpeIDs
+		r.ContentSetVariants = csVariants
+	}
 
 	r.Cpes = cpeIDs
 	r.Variants = variants
 	r.NewerCpes = newerCpes
 	r.NewerVariants = newerVariants
-	r.ContentSetCpes = csCpeIDs
-	r.ContentSetVariants = csVariants
 }
 
 func (r *ProcessedRequest) processProducts(c *Cache, opts *options) []ProductsPackage {

--- a/vmaas/vulnerabilities_test.go
+++ b/vmaas/vulnerabilities_test.go
@@ -95,8 +95,8 @@ func TestCSAF(t *testing.T) {
 
 	products := make([]ProductsPackage, 0, len(matrix))
 	for _, m := range matrix {
-		varCpes := []variantCPE{{DefaultVariantSuffix, 1}, {DefaultVariantSuffix, 2}}
-		pp := cpes2products(&c, varCpes, m.nameID, m.pkgID, []ModuleStream{ms}, m.pkg, &defaultOpts)
+		pp := cpes2products(&c, []VariantSuffix{DefaultVariantSuffix}, []CpeID{1, 2}, m.nameID, m.pkgID,
+			[]ModuleStream{ms}, m.pkg, &defaultOpts)
 		assert.Equal(t, m.fixed, pp.ProductsFixed)
 		assert.Equal(t, m.unfixed, pp.ProductsUnfixed)
 		// duplicate products to cover code handling duplicates


### PR DESCRIPTION
productsWithUnfixedCVEs were created for each variant-cpe combination but they are needed only for cpes with N/A variation

removed duplicities in variants and cpes

split cpe and variant lists

RHINENG-16730