### PR TITLE
fix: last repo in slice doesn't mean last changed repo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,10 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - goconst
+        path: _test\.go
 formatters:
   enable:
     - gofmt

--- a/vmaas/cache_test.go
+++ b/vmaas/cache_test.go
@@ -140,6 +140,8 @@ func mockCache() *Cache {
 	important := ImportantCveImpact
 	low := LowCveImpact
 	lastChange, _ := time.Parse(time.RFC3339, "2024-11-18T17:58:00+01:00")
+	recentChange, _ := time.Parse(time.RFC3339, "2024-11-20T10:00:00+01:00")
+	oldChange, _ := time.Parse(time.RFC3339, "2024-01-01T10:00:00+01:00")
 	updated1, _ := time.Parse(time.RFC3339, "2020-10-10T11:00:45+02:00")
 	updated2, _ := time.Parse(time.RFC3339, "2021-10-10T11:00:45+02:00")
 	return &Cache{
@@ -260,6 +262,8 @@ func mockCache() *Cache {
 			42: {RepoDetailCommon: RepoDetailCommon{Releasever: "8.2"}},
 			43: {RepoDetailCommon: RepoDetailCommon{Releasever: "8.3"}, ThirdParty: true},
 			44: {RepoDetailCommon: RepoDetailCommon{Releasever: "8.4"}, LastChange: &lastChange},
+			45: {RepoDetailCommon: RepoDetailCommon{Releasever: "9.0"}, LastChange: &recentChange},
+			46: {RepoDetailCommon: RepoDetailCommon{Releasever: "9.1"}, LastChange: &oldChange},
 		},
 
 		CveDetail: map[string]CveDetail{
@@ -278,6 +282,7 @@ func mockCache() *Cache {
 			"rhel-6-server-rpms": {41, 42},
 			"rhel-7-server-rpms": {43},
 			"rhel-8-server-rpms": {44},
+			"rhel-9-server-rpms": {45, 46},
 		},
 
 		CpeID2Label: map[CpeID]CpeLabel{

--- a/vmaas/common.go
+++ b/vmaas/common.go
@@ -17,6 +17,7 @@ const (
 	ImportantCveImpact  = "Important"
 	ModerateCveImpact   = "Moderate"
 	LowCveImpact        = "Low"
+	defaultOrg          = "DEFAULT"
 )
 
 var (
@@ -551,7 +552,7 @@ func getRepoIDs(c *Cache, p *ProcessedRequest, opts *options) repoIDMaps { //nol
 	org := p.OriginalRequest.Organization
 	// If organization is not in the updates/vulnerabilities request or is not known, assume DEFAULT
 	if _, ok := c.RepoOrgs[org]; !ok {
-		org = "DEFAULT"
+		org = defaultOrg
 	}
 	if p.Updates.RepoList == nil && len(p.Updates.RepoPaths) == 0 {
 		for _, r := range c.RepoIDs {

--- a/vmaas/common_test.go
+++ b/vmaas/common_test.go
@@ -105,7 +105,7 @@ func testReleaseverBasearch(t *testing.T, f func(*Cache, *string, RepoID) bool, 
 func testOrg(t *testing.T, f func(*Cache, string, RepoID) bool, input string) {
 	c := Cache{
 		RepoDetails: map[RepoID]RepoDetail{
-			1: {RepoDetailCommon: RepoDetailCommon{Organization: "DEFAULT"}},
+			1: {RepoDetailCommon: RepoDetailCommon{Organization: defaultOrg}},
 			2: {RepoDetailCommon: RepoDetailCommon{Organization: "ABCD"}},
 		},
 	}
@@ -142,7 +142,7 @@ func TestPassOrg(t *testing.T) {
 //nolint:funlen
 func TestGetRepoIDs(t *testing.T) {
 	updates := Updates{}
-	originalRequestDefaultOrg := Request{Organization: "DEFAULT"}
+	originalRequestDefaultOrg := Request{Organization: defaultOrg}
 	originalRequestWithoutOrg := Request{}
 	originalRequestOtherOrg := Request{Organization: "ABCD"}
 	originalRequestUnknownOrg := Request{Organization: "EFGH"}
@@ -153,14 +153,14 @@ func TestGetRepoIDs(t *testing.T) {
 	c := Cache{
 		RepoIDs: []RepoID{1, 2, 3, 4},
 		RepoDetails: map[RepoID]RepoDetail{
-			1: {RepoDetailCommon: RepoDetailCommon{Releasever: x8664, Basearch: el9, Organization: "DEFAULT"}},
-			2: {RepoDetailCommon: RepoDetailCommon{Releasever: x8664, Basearch: el9, Organization: "DEFAULT"}},
-			3: {RepoDetailCommon: RepoDetailCommon{Releasever: x8664, Basearch: el9, Organization: "DEFAULT"}},
+			1: {RepoDetailCommon: RepoDetailCommon{Releasever: x8664, Basearch: el9, Organization: defaultOrg}},
+			2: {RepoDetailCommon: RepoDetailCommon{Releasever: x8664, Basearch: el9, Organization: defaultOrg}},
+			3: {RepoDetailCommon: RepoDetailCommon{Releasever: x8664, Basearch: el9, Organization: defaultOrg}},
 			4: {RepoDetailCommon: RepoDetailCommon{Releasever: x8664, Basearch: el9, Organization: "ABCD"}},
 		},
 		RepoOrgs: map[string]bool{
-			"DEFAULT": true,
-			"ABCD":    true,
+			defaultOrg: true,
+			"ABCD":     true,
 		},
 	}
 
@@ -217,7 +217,7 @@ func TestGetRepoIDs(t *testing.T) {
 		RepoDetailCommon: RepoDetailCommon{
 			Releasever:   x8664,
 			Basearch:     el9,
-			Organization: "DEFAULT",
+			Organization: defaultOrg,
 		},
 		URL: "http://example.com/content/dist/rhel/rhui/server/7/7Server/x86_64/os/repodata",
 	}
@@ -614,7 +614,7 @@ func TestApplicability(t *testing.T) {
 		ID2Evr: map[EvrID]utils.Evr{
 			1: {Epoch: 0, Version: "1", Release: "1"},
 			2: {Epoch: 0, Version: "2", Release: "2"},
-			3: {Epoch: 0, Version: "3", Release: "el7a"}, // excluded release in defaultOpts
+			3: {Epoch: 0, Version: "3", Release: el7aRelease}, // excluded release in defaultOpts
 		},
 		PackageDetails: map[PkgID]PackageDetail{
 			1: {NameID: 1, EvrID: 1, ArchID: 1}, // kernel, noarch
@@ -695,10 +695,10 @@ func TestAnyReleaseExcluded(t *testing.T) {
 		expected bool
 	}{
 		{"empty release", []string{}, false},
-		{"single excluded", []string{"el7a"}, true},
-		{"single excluded with dot", []string{"1.el7a"}, true},
-		{"multiple first excluded", []string{"el7a", "el8"}, true},
-		{"multiple second excluded", []string{"el8", "1.el7a"}, true},
+		{"single excluded", []string{el7aRelease}, true},
+		{"single excluded with dot", []string{"1." + el7aRelease}, true},
+		{"multiple first excluded", []string{el7aRelease, "el8"}, true},
+		{"multiple second excluded", []string{"el8", "1." + el7aRelease}, true},
 		{"single not excluded", []string{"el8"}, false},
 		{"single not excluded with dot", []string{"1.el8"}, false},
 		{"multiple not excluded", []string{"1.el8", "el9"}, false},

--- a/vmaas/options.go
+++ b/vmaas/options.go
@@ -1,7 +1,9 @@
 package vmaas
 
+const el7aRelease = "el7a"
+
 var defaultOpts = options{
-	20, true, map[string]bool{"kernel-alt": true}, map[string]bool{"el7a": true}, true, true, "",
+	20, true, map[string]bool{"kernel-alt": true}, map[string]bool{el7aRelease: true}, true, true, "",
 }
 
 type options struct {

--- a/vmaas/options_test.go
+++ b/vmaas/options_test.go
@@ -41,7 +41,7 @@ func TestExcludedPackagesOption(t *testing.T) {
 
 func TestExcludedReleasesOption(t *testing.T) {
 	api := new(API)
-	rel := map[string]bool{"el7a": true}
+	rel := map[string]bool{el7aRelease: true}
 	func(api *API, opts ...Option) {
 		applyOptions(api, opts)
 		assert.Equal(t, rel, api.options.excludedReleases)

--- a/vmaas/repos.go
+++ b/vmaas/repos.go
@@ -20,6 +20,9 @@ type Repos struct {
 func filterInputRepos(c *Cache, repos []string, req *ReposRequest) []string {
 	isDuplicate := make(map[string]bool, len(repos))
 	filteredRepos := make([]string, 0, len(repos))
+	if req.ModifiedSince != nil && req.ModifiedSince.After(time.Now()) {
+		return filteredRepos
+	}
 	for _, repo := range repos {
 		if repo == "" || isDuplicate[repo] {
 			continue
@@ -28,21 +31,25 @@ func filterInputRepos(c *Cache, repos []string, req *ReposRequest) []string {
 		if !found || len(repoIDs) == 0 {
 			continue
 		}
-		repoDetail, found := c.RepoDetails[repoIDs[len(repoIDs)-1]]
-		if !found {
-			continue
-		}
 
-		if req.ModifiedSince != nil {
-			if req.ModifiedSince.After(time.Now()) {
+		anyRepoMatches := false
+		for _, repoID := range repoIDs {
+			repoDetail, found := c.RepoDetails[repoID]
+			if !found {
 				continue
 			}
-			if repoDetail.LastChange != nil && repoDetail.LastChange.Before(*req.ModifiedSince) {
+			if req.ModifiedSince != nil {
+				if repoDetail.LastChange != nil && repoDetail.LastChange.Before(*req.ModifiedSince) {
+					continue
+				}
+			}
+			if !req.ThirdParty && repoDetail.ThirdParty {
 				continue
 			}
+			anyRepoMatches = true
+			break
 		}
-
-		if !req.ThirdParty && repoDetail.ThirdParty {
+		if !anyRepoMatches {
 			continue
 		}
 

--- a/vmaas/repos_test.go
+++ b/vmaas/repos_test.go
@@ -13,19 +13,42 @@ func TestFilterInputRepos(t *testing.T) {
 
 	// usual case
 	filtered := filterInputRepos(c, repos, &ReposRequest{})
-	assert.Equal(t, 2, len(filtered))
+	assert.Equal(t, 3, len(filtered))
 
 	// ThirdParty
 	req := &ReposRequest{ThirdParty: true}
 	filtered = filterInputRepos(c, repos, req)
-	assert.Equal(t, 3, len(filtered))
+	assert.Equal(t, 4, len(filtered))
 
 	// With LastChange before req.ModifiedSince
 	testTime, _ := time.Parse(time.RFC3339, "2024-11-19T18:01:01+01:00")
 	req = &ReposRequest{ModifiedSince: &testTime}
 	filtered = filterInputRepos(c, repos, req)
+	assert.Equal(t, 2, len(filtered))
+	assert.Contains(t, filtered, "rhel-6-server-rpms")
+	assert.Contains(t, filtered, "rhel-9-server-rpms")
+}
+
+func TestFilterInputReposMultiRepoLastChange(t *testing.T) {
+	// Test that a content set label with multiple repoIDs is included
+	// when ANY repoID has a recent LastChange, even if the last repoID
+	// in the slice has an old LastChange.
+	c := mockCache()
+
+	// modified_since between the two LastChange values
+	modifiedSince, _ := time.Parse(time.RFC3339, "2024-06-01T00:00:00+00:00")
+	req := &ReposRequest{ModifiedSince: &modifiedSince}
+	filtered := filterInputRepos(c, []string{"rhel-9-server-rpms"}, req)
+	// one repoID has LastChange after modified_since, so the label must be included
 	assert.Equal(t, 1, len(filtered))
-	assert.Equal(t, "rhel-6-server-rpms", filtered[0])
+	assert.Equal(t, "rhel-9-server-rpms", filtered[0])
+
+	// modified_since after both LastChange values
+	modifiedSince2, _ := time.Parse(time.RFC3339, "2024-12-01T00:00:00+00:00")
+	req = &ReposRequest{ModifiedSince: &modifiedSince2}
+	filtered = filterInputRepos(c, []string{"rhel-9-server-rpms"}, req)
+	// both repoIDs have LastChange before modified_since, label must be excluded
+	assert.Equal(t, 0, len(filtered))
 }
 
 func TestRepoID2CPEs(t *testing.T) {

--- a/vmaas/vulnerabilities.go
+++ b/vmaas/vulnerabilities.go
@@ -301,7 +301,7 @@ func (r *ProcessedRequest) processRepos(c *Cache) {
 }
 
 func (r *ProcessedRequest) processProducts(c *Cache, opts *options) []ProductsPackage {
-	productsPackages := make([]ProductsPackage, 0)
+	productsPackages := make([]ProductsPackage, 0, len(r.Packages))
 	for _, pkg := range r.Packages {
 		nameID := c.Packagename2ID[pkg.Nevra.Name]
 		evrID := c.Evr2ID[utils.Evr{Epoch: pkg.Nevra.Epoch, Release: pkg.Nevra.Release, Version: pkg.Nevra.Version}]


### PR DESCRIPTION
check properly all repoIDs obtained from repo/content set label when the label maps to many IDs - e.g. for each release version - and the last one in slice is some no longer updated version, the repository change is missed

RHINENG-25191