### PR TITLE
fix: don't put empty slice to the output

### DIFF
--- a/vmaas/repos.go
+++ b/vmaas/repos.go
@@ -116,8 +116,11 @@ func (c *Cache) getRepoDetails(req *ReposRequest, repos []string, repoID2Erratum
 		if latestRepoChange == nil || (latestChange != nil && latestChange.After(*latestRepoChange)) {
 			latestRepoChange = latestChange
 		}
-		repoDetails[repo] = repoDetailSlice
-		actualPageSize += len(repoDetailSlice)
+		repoCount := len(repoDetailSlice)
+		if repoCount > 0 {
+			repoDetails[repo] = repoDetailSlice
+		}
+		actualPageSize += repoCount
 	}
 	return repoDetails, latestRepoChange, actualPageSize
 }


### PR DESCRIPTION
when combination of has_packages=true and modified_since combination of filters is used, the result may be an empty slice and in the response is only the content set label mapped to empty list